### PR TITLE
Dealing with longer config/sheet names

### DIFF
--- a/Main
+++ b/Main
@@ -17,8 +17,8 @@ Dim Response As Integer
 Dim ThirdAngle As Boolean
 
 Dim cusPropMgr As SldWorks.CustomPropertyManager
-Dim ConfigNamesArray As Variant
-Dim ConfigName As Variant
+Dim ConfigNamesArray() As String
+Dim ConfigName As String
 Dim SheetName As String
 
 Dim retval As Boolean
@@ -53,11 +53,13 @@ SAVEASPATH = Left(swModel.GetPathName(), Len(swModel.GetPathName()) - Len(swMode
 Debug.Print ("Save Path: " & SAVEASPATH)
 
 'Get Configuration names and set active configuration to raw material
+
+Dim ConfigNumber As Integer
+ConfigNumber = swModel.GetConfigurationCount
+ReDim ConfigNamesArray(ConfigNumber - 1)
 ConfigNamesArray = swModel.GetConfigurationNames
 Debug.Print ("ConfigNamesArray Size: " & UBound(ConfigNamesArray))
 swModel.ShowConfiguration2 ConfigNamesArray(0)
-Dim ConfigNumber As Integer
-ConfigNumber = swModel.GetConfigurationCount
 
 'Get the amount of times to run the macro
 'Dim RunTest As Integer
@@ -132,8 +134,9 @@ Debug.Print ("******Loop Start******")
     For j = 1 To DocNums(1) 'UBound(ConfigNamesArray) 'Limiting loop to run while configs are there
     Debug.Print ("___________" & vbCrLf & "For Loop: 'i' = " & i) 'Telling me where we are (Hopefully it gets past 0)
 
-        SheetName = Left(ConfigNamesArray(i), 3)            'Only works if configs are done as "### Operation"
+        'SheetName = Left(ConfigNamesArray(i), 3)            'Only works if configs are done as "### Operation"
         ConfigName = ConfigNamesArray(i)                    'Just getting Config Name (Might remove later)
+        SheetName = NameThatSheet(ConfigNamesArray(i))
         Debug.Print ("Config Name: " & ConfigNamesArray(i))
         Debug.Print ("Sheet Name: " & SheetName)
         SheetNames(i) = SheetName
@@ -209,4 +212,3 @@ Debug.Print ("****END****")
 Debug.Print ("==============")
 
 End Sub
-

--- a/Module
+++ b/Module
@@ -112,3 +112,34 @@ Next i
 Debug.Print ("****EdgeBreakCheck Function End****")
 EdgeBreakCheck = True
 End Function
+
+Function NameThatSheet(ConfigName As String) As String 'Function to Check for "(" in config names
+Debug.Print ("*****NameThatSheet Start*****")
+Dim CharCheck() As String
+Dim CharNum As Integer
+Dim i As Integer
+Dim NameLength
+Dim bool As Boolean
+'Find Character Number and redim the array to match
+CharNum = Len(ConfigName)
+ReDim CharCheck(CharNum - 1)
+
+'Break the string down into an array of characters and check them for "(" then find when the ")" comes
+For i = 0 To CharNum - 1
+    CharCheck(i) = Mid$(ConfigName, i + 1, 1)
+    If CharCheck(i) = "(" Then
+        bool = True
+    ElseIf CharCheck(i) = ")" Then
+        NameLength = i + 1
+    End If
+Next i
+
+'Check to see if there is an open paren. If not then name sheet as normal
+If bool = True Then
+    NameThatSheet = Left(ConfigName, NameLength)
+Else
+    NameThatSheet = Left(ConfigName, 3)
+End If
+
+Debug.Print ("Name of Sheet: " & NameThatSheet)
+End Function


### PR DESCRIPTION
Added Function: NameThatSheet to deal with naming issues and multisheet drawings (Drawings that require multiple sheets with different configurations but count as one sheet)